### PR TITLE
Add Shimmer genesis snapshot

### DIFF
--- a/shimmer/protocol_parameters.json
+++ b/shimmer/protocol_parameters.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "networkName": "shimmer",
+  "bech32HRP": "smr",
+  "minPoWScore": 1500,
+  "belowMaxDepth": 15,
+  "rentStructure": {
+    "vByteCost": 100,
+    "vByteFactorData": 1,
+    "vByteFactorKey": 10
+  },
+  "tokenSupply": "1813620509061365"
+}


### PR DESCRIPTION
It's time to verify the Shimmer genesis snapshot!

To do this, we need the help of our community.

## Please follow the next steps:

- Copy the following bash script into a file called `create_shimmer_genesis.sh`

```bash
#!/bin/bash

if [[ "$OSTYPE" != "darwin"* && "$EUID" -ne 0 ]]; then
  echo "Please run as root or with sudo"
  exit
fi

# create data dir
if [ ! -d data ]; then
    echo "data directory not found. Creating..."
    mkdir data    
fi

# remove old results
if [ -f data/genesis_snapshot.bin ]; then
    rm data/genesis_snapshot.bin
fi

if [ ! -f data/protocol_parameters.json ]; then
    echo "Shimmer protocol parameters not found. Downloading..."
    curl -L https://github.com/iotaledger/global-snapshots/raw/shimmer-genesis/shimmer/protocol_parameters.json -o data/protocol_parameters.json
fi

if [ ! -f data/shimmer.json ]; then
    echo "Shimmer staking results not found. Downloading..."
    curl -L https://github.com/iotaledger/participation-events/raw/master/results/staking/shimmer.json -o data/shimmer.json
fi

if [ ! -f data/genesis_snapshot_orig.bin ]; then
    echo "Shimmer genesis snapshot (original) not found. Downloading..."
    curl -L https://github.com/iotaledger/global-snapshots/raw/shimmer-genesis/shimmer/genesis_snapshot.bin -o data/genesis_snapshot_orig.bin
fi

# set correct permissions
if [[ "$OSTYPE" != "darwin"* ]]; then
    chown -R 65532:65532 data
fi

# create genesis snapshot from Shimmer staking results + Treasury DAO + Tangle Association addresses
docker run --mount type=bind,source="$(pwd)"/data,target=/app/data \
    iotaledger/hornet:2.0.0-beta.8 \
    tool snap-gen --protocolParametersPath data/protocol_parameters.json \
    --genesisAddressesPath=data/shimmer.json \
    --genesisAddresses=smr1qrmakyqt5ezm5k9c0sk39gwfavpktxkjmx0jvh9ejxjq6pr6d39egv2mvuc:181362050906137,smr1qpjva0y6qwjmv42dspw2se2776l5qr0r5p2s5m7nrg73qhvm6a6y7uvqxn6:181362050906136 \
    --outputPath data/genesis_snapshot.bin

# print genesis snapshot hash
docker run --mount type=bind,source="$(pwd)"/data,target=/app/data \
    iotaledger/hornet:2.0.0-beta.8 \
    tool snap-hash --fullSnapshotPath data/genesis_snapshot.bin

# print sha256 hashes
echo "calculating SHA256 hashes..."
shasum -a 256 data/genesis_snapshot*.bin
```

## What does this script do?
- it downloads the initial protocol parameters for the Shimmer network which are attached to this PR.
- it downloads the community verified result of the Shimmer staking from https://github.com/iotaledger/participation-events/pull/2
- it adds the two additional addresses for the "initial [Shimmer Ecosystem Funding Proposal](https://govern.iota.org/t/discussion-proposal-to-increase-the-shimmer-supply-for-a-community-treasury/1291) and its [follow-up proposal](https://govern.iota.org/t/discussion-follow-up-proposal-to-the-establishment-of-a-shimmer-ecosystem-fund/1315)" which was decided and verified by the community here https://github.com/iotaledger/participation-events/pull/10
- it creates a genesis snapshot with all the downloaded information
- it downloads the "original" genesis snapshot which is attached to this PR
- it calculates the SHA256 of the generated and the downloaded genesis snapshot files

## What do I need to check?
- please verify that the content of the downloaded `protocol_parameters.json` is correct according to https://github.com/iotaledger/tips/blob/main/tips/TIP-0032/tip-0032.md#global-parameters
- please verify that the two additional addresses for the "initial [Shimmer Ecosystem Funding Proposal](https://govern.iota.org/t/discussion-proposal-to-increase-the-shimmer-supply-for-a-community-treasury/1291) and its [follow-up proposal](https://govern.iota.org/t/discussion-follow-up-proposal-to-the-establishment-of-a-shimmer-ecosystem-fund/1315)" in the above script are correct according to https://github.com/iotaledger/tips/blob/main/tips/TIP-0032/tip-0032.md#genesis-supply
- execute the script with `sudo ./create_shimmer_genesis.sh` and check that the shown SHA256 of the generated and the downloaded genesis snapshot files match

Please approve this PR in case you are sure that everything is correct.
